### PR TITLE
Remove unused dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,20 +59,16 @@
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-compatibility-server</artifactId>
             <version>${vaadin.version}</version>
+	    <exclusions>
+                <exclusion>
+                    <groupId>com.vaadin.external.flute</groupId>
+                    <artifactId>flute</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-compatibility-shared</artifactId>
-            <version>${vaadin.version}</version>
-        </dependency>
-         <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-compatibility-client-compiled</artifactId>
-            <version>${vaadin.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-themes</artifactId>
             <version>${vaadin.version}</version>
         </dependency>
         <dependency>
@@ -140,11 +136,6 @@
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
 			<version>20140107</version>
-		</dependency>
-		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-jaxrs</artifactId>
-			<version>1.9.4</version>
 		</dependency>
 
 		<!-- XML -->


### PR DESCRIPTION
@edureka-git Hi, I am a user of project **_com.edurekademo.tutorial:addressbook:2.0_**. I found that its pom file introduced **_30_** dependencies. However, among them, **_6_** libraries (**_20%_**) have not been used by your project (the redundant dependencies are listed below). This PR helps **_com.edurekademo.tutorial:addressbook:2.0_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
com.vaadin:vaadin-themes:jar:8.0.0.alpha2:compile
com.vaadin.external.flute:flute:jar:1.3.0.gg2:compile
org.codehaus.jackson:jackson-core-asl:jar:1.9.4:compile
com.vaadin:vaadin-compatibility-client-compiled:jar:8.0.0.alpha2:compile
org.codehaus.jackson:jackson-mapper-asl:jar:1.9.4:compile
org.codehaus.jackson:jackson-jaxrs:jar:1.9.4:compile